### PR TITLE
ZPS-6998: fix for nils in ModelStatusResult.

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -238,7 +238,7 @@ func (p *Proxy) PutModels(ctx context.Context, models *data_receiver.Models) (*d
 	var r *data_receiver.ModelStatusResult
 
 	if models.DetailedResponse {
-		failedModels = make([]*data_receiver.ModelError, len(models.Models))
+		failedModels = make([]*data_receiver.ModelError, 0, len(models.Models))
 	}
 
 	if len(models.Models) > 0 {

--- a/splitter/splitter.go
+++ b/splitter/splitter.go
@@ -207,7 +207,7 @@ func (s *Splitter) PutModels(ctx context.Context, models *data_receiver.Models, 
 	var r *data_receiver.ModelStatusResult
 
 	if models.DetailedResponse {
-		failedModels = make([]*data_receiver.ModelError, len(models.Models)*len(s.outputs))
+		failedModels = make([]*data_receiver.ModelError, 0, len(models.Models)*len(s.outputs))
 	}
 
 	for _, output := range s.outputs {


### PR DESCRIPTION
Fixes errors like the following for clients using the proxy or splitter
modules.

    grpc: error while marshaling: proto: repeated field FailedModels has nil element
