### PR TITLE
Zing-38290: added retry/backoff 

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -542,7 +542,7 @@ func (e *Endpoint) registerMetrics(ctx context.Context, metrics []*data_receiver
 	)
 	if err != nil {
 		log.Log(e, log.LevelError, log.Fields{"error": err}, "Unable to register metrics")
-		return successes, metricIDsNamesAndHashes
+		return successes, []MetricIDNameAndHash{}
 	}
 
 	failedMetrics := make([]*FailedRegistrationContext, 0)
@@ -566,7 +566,7 @@ func (e *Endpoint) registerMetrics(ctx context.Context, metrics []*data_receiver
 	}
 
 	if len(failedMetrics) > 0 {
-		// retrying to register failed metrics from batch
+		// retrying to register failed metrics from batchg
 		expBoff.Reset()
 		metricsToRetry := extractMetrics(failedMetrics)
 		retryResponse, err := backoff.Retry(

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -566,7 +566,7 @@ func (e *Endpoint) registerMetrics(ctx context.Context, metrics []*data_receiver
 	}
 
 	if len(failedMetrics) > 0 {
-		// retrying to register failed metrics from batchg
+		// retrying to register failed metrics from batch
 		expBoff.Reset()
 		metricsToRetry := extractMetrics(failedMetrics)
 		retryResponse, err := backoff.Retry(

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -536,7 +536,7 @@ func (e *Endpoint) registerMetrics(ctx context.Context, metrics []*data_receiver
 	}
 
 	if len(failedMetrics) > 0 {
-		//retrying to register failed metrics from batch
+		// retrying to register failed metrics from batch
 		expBoff.Reset()
 		retryResponse, err := backoff.Retry(
 			ctx,

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -340,7 +340,6 @@ var _ = Describe("Endpoint", func() {
 				// Skip bundler delay thresholds.
 				e.Flush()
 			})
-
 		})
 
 		Context("PutModels", func() {

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -2,6 +2,7 @@ package endpoint_test
 
 import (
 	"context"
+	"errors"
 	stdlog "log"
 	"os"
 	"testing"
@@ -157,6 +158,189 @@ var _ = Describe("Endpoint", func() {
 				// Skip bundler delay thresholds.
 				e.Flush()
 			})
+
+			It("returns failed metrics if CreateOrUpdateMetrics fails on first try", func() {
+				regout.On("CreateOrUpdateMetrics", mock.Anything, mock.Anything).
+					Return(nil, errors.New("initial registration error"))
+
+				inputMetrics := []*data_receiver.Metric{
+					{
+						Metric:    "failmetric",
+						Value:     123,
+						Timestamp: time.Now().UnixNano() / 1e6,
+						Dimensions: map[string]string{
+							"source": "sdk.zdm.test",
+							"app":    "sdktest",
+						},
+					},
+				}
+
+				compactMetrics, failedMetrics := e.ConvertMetrics(context.TODO(), inputMetrics)
+
+				Ω(compactMetrics).Should(HaveLen(0))
+				Ω(failedMetrics).Should(HaveLen(1))
+				Ω(failedMetrics[0].Metric).Should(Equal("failmetric"))
+
+				e.Flush()
+			})
+
+			It("returns failed metrics if retry after partial failure also fails", func() {
+				responses := make([]*data_registry.RegisterMetricVerboseResponse, 0)
+				verboseResponse := &data_registry.RegisterMetricVerboseResponse{
+					Response: &data_registry.RegisterMetricResponse{
+						InstanceId: "id123456canonical1",
+						Name:       "canonical1",
+					},
+				}
+				errorResponse := &data_registry.RegisterMetricVerboseResponse{
+					Error: "error occured",
+				}
+				responses = append(responses, verboseResponse, errorResponse)
+				regCreateOrUpdateStreamingClientMock := &data_registry.MockDataRegistryService_CreateOrUpdateMetricsClient{}
+				regCreateOrUpdateStreamingClientMock.On("Send", mock.Anything).Return(nil)
+				regCreateOrUpdateStreamingClientMock.On("CloseAndRecv").Return(&data_registry.RegisterMetricsResponse{
+					Responses: responses,
+				}, nil)
+
+				regout.On("CreateOrUpdateMetrics", mock.Anything, mock.Anything).
+					Return(regCreateOrUpdateStreamingClientMock, nil).Once()
+				regout.On("CreateOrUpdateMetrics", mock.Anything, mock.Anything).
+					Return(nil, errors.New("Error closing stream")).Times(3)
+				inputMetrics := []*data_receiver.Metric{
+					{
+						Metric:    "canonical1",
+						Value:     1,
+						Timestamp: time.Now().UnixNano() / 1e6,
+						Dimensions: map[string]string{
+							"source": "sdk.zdm.test",
+							"app":    "sdktest",
+						},
+						MetadataFields: &_struct.Struct{
+							Fields: map[string]*_struct.Value{
+								"srckey": {
+									Kind: &_struct.Value_StringValue{
+										StringValue: "srcvalue",
+									},
+								},
+							},
+						},
+					},
+					{
+						Metric:    "failing1",
+						Value:     2,
+						Timestamp: time.Now().UnixNano() / 1e6,
+						Dimensions: map[string]string{
+							"source": "sdk.zdm.test",
+							"app":    "sdktest",
+						},
+						MetadataFields: &_struct.Struct{
+							Fields: map[string]*_struct.Value{
+								"srckey": {
+									Kind: &_struct.Value_StringValue{
+										StringValue: "srcvalue",
+									},
+								},
+							},
+						},
+					},
+				}
+				compactMetrics, failedMetrics := e.ConvertMetrics(context.TODO(), inputMetrics)
+
+				Ω(failedMetrics).Should(HaveLen(1))
+				Ω(compactMetrics).Should(HaveLen(1))
+				// Skip bundler delay thresholds.
+				e.Flush()
+			})
+
+			It("returns compact metrics if failed metrics from batch were registered after retry", func() {
+				firstResponses := make([]*data_registry.RegisterMetricVerboseResponse, 0)
+				verboseResponse1 := &data_registry.RegisterMetricVerboseResponse{
+					Response: &data_registry.RegisterMetricResponse{
+						InstanceId: "id123456canonical1",
+						Name:       "canonical1",
+					},
+				}
+				errorResponse := &data_registry.RegisterMetricVerboseResponse{
+					Error: "error occured",
+				}
+				firstResponses = append(firstResponses, verboseResponse1, errorResponse)
+
+				firstStreamMock := &data_registry.MockDataRegistryService_CreateOrUpdateMetricsClient{}
+				firstStreamMock.On("Send", mock.Anything).Return(nil)
+				firstStreamMock.On("CloseAndRecv").Return(&data_registry.RegisterMetricsResponse{
+					Responses: firstResponses,
+				}, nil)
+
+				retryResponses := make([]*data_registry.RegisterMetricVerboseResponse, 0)
+				verboseResponse2 := &data_registry.RegisterMetricVerboseResponse{
+					Response: &data_registry.RegisterMetricResponse{
+						InstanceId: "id123456canonical2",
+						Name:       "canonical2",
+					},
+				}
+				retryResponses = append(retryResponses, verboseResponse2)
+
+				retryStreamMock := &data_registry.MockDataRegistryService_CreateOrUpdateMetricsClient{}
+				retryStreamMock.On("Send", mock.Anything).Return(nil)
+				retryStreamMock.On("CloseAndRecv").Return(&data_registry.RegisterMetricsResponse{
+					Responses: retryResponses,
+				}, nil)
+
+				// 1 registered, 1 failed
+				regout.On("CreateOrUpdateMetrics", mock.Anything, mock.Anything).
+					Return(firstStreamMock, nil).Once()
+				// trying to reregister the failed one, error occurred
+				regout.On("CreateOrUpdateMetrics", mock.Anything, mock.Anything).
+					Return(nil, errors.New("Error closing stream")).Once()
+				// retrying with backoff, 1 registered
+				regout.On("CreateOrUpdateMetrics", mock.Anything, mock.Anything).
+					Return(retryStreamMock, nil).Once()
+				inputMetrics := []*data_receiver.Metric{
+					{
+						Metric:    "canonical1",
+						Value:     1,
+						Timestamp: time.Now().UnixNano() / 1e6,
+						Dimensions: map[string]string{
+							"source": "sdk.zdm.test",
+							"app":    "sdktest",
+						},
+						MetadataFields: &_struct.Struct{
+							Fields: map[string]*_struct.Value{
+								"srckey": {
+									Kind: &_struct.Value_StringValue{
+										StringValue: "srcvalue",
+									},
+								},
+							},
+						},
+					},
+					{
+						Metric:    "canonical2",
+						Value:     2,
+						Timestamp: time.Now().UnixNano() / 1e6,
+						Dimensions: map[string]string{
+							"source": "sdk.zdm.test",
+							"app":    "sdktest",
+						},
+						MetadataFields: &_struct.Struct{
+							Fields: map[string]*_struct.Value{
+								"srckey": {
+									Kind: &_struct.Value_StringValue{
+										StringValue: "srcvalue",
+									},
+								},
+							},
+						},
+					},
+				}
+				compactMetrics, failedMetrics := e.ConvertMetrics(context.TODO(), inputMetrics)
+
+				Ω(failedMetrics).Should(BeEmpty())
+				Ω(compactMetrics).Should(HaveLen(2))
+				// Skip bundler delay thresholds.
+				e.Flush()
+			})
+
 		})
 
 		Context("PutModels", func() {

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -49,12 +49,14 @@ var _ = Describe("Endpoint", func() {
 	Context("with basic configuration", func() {
 		BeforeEach(func() {
 			e, err = endpoint.New(endpoint.Config{
-				APIKey:         "x",
-				TestClient:     out,
-				TestRegClient:  regout,
-				MinTTL:         10000,
-				MaxTTL:         100000,
-				CacheSizeLimit: 200000,
+				APIKey:          "x",
+				TestClient:      out,
+				TestRegClient:   regout,
+				MinTTL:          10000,
+				MaxTTL:          100000,
+				InitialBackoff:  10 * time.Millisecond,
+				NumberOfRetries: 3,
+				CacheSizeLimit:  200000,
 			})
 		})
 

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 )
 
 require (
+	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/cbroglie/mustache v1.4.0 h1:Azg0dVhxTml5me+7PsZ7WPrQq1Gkf3WApcHMjMprYoU=
 github.com/cbroglie/mustache v1.4.0/go.mod h1:SS1FTIghy0sjse4DUVGV1k/40B1qE1XkD9DtDsHo9iM=
+github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=
+github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=


### PR DESCRIPTION
- added retry mechanism using cenkalti/backoff/v5
      -   3 attempts for the initial full batch
      -   2 additional attempts for failed individual metrics
      -   preserved metrics order and logging logic
      -  if retrying to register failed metrics from batch fails completely, then errors from previous trying are logged, as nil is returned 
 - added tests